### PR TITLE
Add kaleido dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 interfaz para analizar censo de arboles frutales
 📦 Carpeta de distribución: ConsultaCultivosApp
 
+## Instalación
+Para ejecutar el código fuente en Python instala las dependencias con:
+```bash
+pip install -r requirements.txt
+```
+El paquete `kaleido` es necesario para que `fig.write_image` exporte los gráficos correctamente.
+
 Contenidos de la carpeta:
 
 - interfaz_tkinter.exe → El archivo ejecutable de la aplicación.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas
 plotly
 fpdf
 pillow
+kaleido


### PR DESCRIPTION
## Summary
- require `kaleido` for image export
- document installation with new dependency in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile interfaz_tkinter.py`
- `python - <<'PY'
import plotly.express as px
fig = px.line(x=[1,2,3], y=[1,4,9])
fig.write_image('test_image.png')
print('image written')
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6864e048d8088330ba19151b23b054a2