### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Para ejecutar el código fuente en Python instala las dependencias con:
 ```bash
 pip install -r requirements.txt
 ```
-El paquete `kaleido` es necesario para que `fig.write_image` exporte los gráficos correctamente.
+Los gráficos se generan con la biblioteca `matplotlib`, incluida en las dependencias.
 
 Contenidos de la carpeta:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 customtkinter
 folium
 pandas
-plotly
 fpdf
 pillow
-kaleido
+matplotlib


### PR DESCRIPTION
## Summary
- switch dependency from `plotly` to `matplotlib`
- remove mention of `kaleido` in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c89751adc833095b1d0665d2c9082